### PR TITLE
Add migration for sales updated_at column

### DIFF
--- a/backend/db/migrations/002_add_updated_at_to_sales.sql
+++ b/backend/db/migrations/002_add_updated_at_to_sales.sql
@@ -1,0 +1,4 @@
+ALTER TABLE sales
+  ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ DEFAULT NOW();
+
+UPDATE sales SET updated_at = COALESCE(updated_at, NOW());

--- a/backend/src/modules/sales/types.ts
+++ b/backend/src/modules/sales/types.ts
@@ -5,6 +5,7 @@ export interface Sale {
   status: string;
   payment_reference: string | null;
   created_at: string;
+  updated_at: string;
 }
 
 export interface SaleItem {


### PR DESCRIPTION
## Summary
- add a follow-up migration that introduces an `updated_at` column on the `sales` table with a default timestamp
- expose the new `updated_at` field on the `Sale` TypeScript type so repository updates continue to compile

## Testing
- not run (PostgreSQL client is unavailable in the container)

------
https://chatgpt.com/codex/tasks/task_e_68d8fd45c274832994039b292e644c42