### PR TITLE
Ensure sales updated_at column via migration

### DIFF
--- a/backend/db/migrations/003_ensure_sales_updated_at.sql
+++ b/backend/db/migrations/003_ensure_sales_updated_at.sql
@@ -1,0 +1,9 @@
+ALTER TABLE sales
+  ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ DEFAULT NOW();
+
+UPDATE sales
+SET updated_at = NOW()
+WHERE updated_at IS NULL;
+
+ALTER TABLE sales
+  ALTER COLUMN updated_at SET DEFAULT NOW();


### PR DESCRIPTION
## Summary
- ensure the sales table has an updated_at column with a default timestamp and populate any missing values

## Testing
- not run (npm registry access is blocked in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68d91b003ec88329af608101f177410c